### PR TITLE
Take base as parameter each time

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Additional properties:
 
 3. What might I use this library for?
    - Naming file versions so that they show up in order.
-   - Encoding a timestamp-plus-tiebreaker as a lexicographically-ordered string `` `${sequence(timestamp)}-${tiebreaker}` ``, so that you can sort by this single field. (E.g., [Lamport timestamps](https://en.wikipedia.org/wiki/Lamport_timestamp) with a process ID tiebreaker.)
-   - I use it in [list-positions](https://github.com/mweidner037/position-strings/#readme)'s [lexicographicString function](https://github.com/mweidner037/list-positions/blob/master/README.md#lexicographic-strings), to assign slowly-growing strings to sequential positions.
+   - Encoding a timestamp-plus-tiebreaker as a lexicographically-ordered string `` `${sequence(timestamp, BASE)}-${tiebreaker}` ``, so that you can sort by this single field. (E.g., [Lamport timestamps](https://en.wikipedia.org/wiki/Lamport_timestamp) with a process ID tiebreaker.)
+   - I use it in [list-positions](https://github.com/mweidner037/list-positions/#readme)'s [lexicographicString function](https://github.com/mweidner037/list-positions#lexicographic-strings), to assign slowly-growing strings to sequential positions.
 
 ## API
 
@@ -53,7 +53,7 @@ import {
 const BASE = 10;
 ```
 
-`sequence(n, base)` returns the n-th entry in the sequence **as an integer**, which you can then `BASE` encode:
+`sequence(n, BASE)` returns the n-th entry in the sequence **as an integer**, which you can then `BASE` encode:
 
 ```ts
 for (let n = 0; n < 100; n++) {
@@ -62,7 +62,7 @@ for (let n = 0; n < 100; n++) {
 // Prints "0", "1", ..., "4", "50", ..., "74", "750", ..., "819"
 ```
 
-`sequenceInv(seq, base)` converts a sequence member back to its index:
+`sequenceInv(seq, BASE)` converts a sequence member back to its index:
 
 ```ts
 console.log(sequenceInv(819, BASE)); // Prints 99
@@ -74,7 +74,7 @@ console.log(sequenceInv(819, BASE)); // Prints 99
 console.log(sequenceInvSafe(5, BASE) === -1); // Prints true
 ```
 
-`successor(seq, base)` is a fast way to go from `sequence(n, base)` to `sequence(n + 1, base)`:
+`successor(seq, BASE)` is a fast way to go from `sequence(n, BASE)` to `sequence(n + 1, BASE)`:
 
 ```ts
 let seq = 0;
@@ -102,4 +102,4 @@ for (let i = 0; i < 100; i++) {
      in front of each number, each d consumes 2^(-d) of the unit interval,
      so we never "reach 1" (overflow to d+1 digits when
      we meant to use d digits).
-- I have not found an existing source describing this sequence, but I believe it is related to [Elias gamma coding](https://en.wikipedia.org/wiki/Elias_gamma_coding).
+- I have not found an existing source describing this sequence, but the binary-encoded base-4 sequence is similar to [Elias gamma coding](https://en.wikipedia.org/wiki/Elias_gamma_coding).

--- a/README.md
+++ b/README.md
@@ -36,47 +36,51 @@ Additional properties:
 3. What might I use this library for?
    - Naming file versions so that they show up in order.
    - Encoding a timestamp-plus-tiebreaker as a lexicographically-ordered string `` `${sequence(timestamp)}-${tiebreaker}` ``, so that you can sort by this single field. (E.g., [Lamport timestamps](https://en.wikipedia.org/wiki/Lamport_timestamp) with a process ID tiebreaker.)
-   - I use it in [position-strings](https://github.com/mweidner037/position-strings/#readme), to assign slowly-growing strings to sequential positions.
+   - I use it in [list-positions](https://github.com/mweidner037/position-strings/#readme)'s [lexicographicString function](https://github.com/mweidner037/list-positions/blob/master/README.md#lexicographic-strings), to assign slowly-growing strings to sequential positions.
 
 ## API
 
-Specify your base to get the functions:
+It's a good idea to specify your base as a constant:
 
 ```ts
-import { lexSequence } from "lex-sequence";
+import {
+  sequence,
+  sequenceInv,
+  sequenceInvSafe,
+  successor,
+} from "lex-sequence";
 
 const BASE = 10;
-const { sequence, sequenceInv, sequenceInvSafe, successor } = lexSequence(BASE);
 ```
 
-`sequence(n)` returns the n-th entry in the sequence **as an integer**, which you can then `BASE` encode:
+`sequence(n, base)` returns the n-th entry in the sequence **as an integer**, which you can then `BASE` encode:
 
 ```ts
 for (let n = 0; n < 100; n++) {
-  console.log(sequence(n).toString(BASE));
+  console.log(sequence(n, BASE).toString(BASE));
 }
 // Prints "0", "1", ..., "4", "50", ..., "74", "750", ..., "819"
 ```
 
-`sequenceInv(seq)` converts a sequence member back to its index:
+`sequenceInv(seq, base)` converts a sequence member back to its index:
 
 ```ts
-console.log(sequenceInv(819)); // Prints 99
+console.log(sequenceInv(819, BASE)); // Prints 99
 ```
 
 "Safe" version that will return -1 instead of throwing an error, if `seq` is not a valid sequence member:
 
 ```ts
-console.log(sequenceInvSafe(5) === -1); // Prints true
+console.log(sequenceInvSafe(5, BASE) === -1); // Prints true
 ```
 
-`successor(seq)` is a fast way to go from `sequence(n)` to `sequence(n+1)`:
+`successor(seq, base)` is a fast way to go from `sequence(n, base)` to `sequence(n + 1, base)`:
 
 ```ts
 let seq = 0;
 for (let i = 0; i < 100; i++) {
   console.log(seq.toString(BASE));
-  seq = successor(seq);
+  seq = successor(seq, BASE);
 }
 // Prints "0", "1", ..., "4", "50", ..., "74", "750", ..., "819"
 ```
@@ -84,7 +88,7 @@ for (let i = 0; i < 100; i++) {
 ## Misc
 
 - `BASE` must even and >= 4. For a base-2 (binary) sequence, binary-encode the numbers from the base-4 sequence.
-- The `BASE` encoding of `sequence(n)` is always as long as the `BASE/2` encoding of `n`.
+- The `BASE` encoding of `sequence(n, BASE)` is always as long as the `BASE/2` encoding of `n`.
 - You can use any alphabet to encode numbers as strings, so long as it consists of `BASE` chars and they are in lexicographic order. E.g., you can use base64 chars in the **non-standard, lexicographic** ordering `+/0-9A-Za-z`.
 - [lexicographic-integer](https://www.npmjs.com/package/lexicographic-integer) implements the same idea, but only in base 16 or 256, with strings that are generally a bit longer than ours.
 - The sequence is as follows, with examples in base 10:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,126 +1,126 @@
+/*
+  The sequence is as follows, with examples in base 10:
+
+  1. Starting with 0, enumerate `BASE/2` numbers. (0, 1, ..., 4.)
+  2. Add 1, multiply by `BASE`, then enumerate `(BASE/2)^2` numbers.
+    (50, 51, ..., 74.)
+  3. Add 1, multiply by `BASE`, then enumerate `(BASE/2)^3` numbers.
+    (750, 751, ..., 874.)
+  4. Repeat this pattern indefinitely, enumerating
+    `(BASE/2)^d` length-d numbers for each d >= 1. Imagining a decimal place
+    in front of each number, each d consumes 2^(-d) of the unit interval,
+    so we never "reach 1" (overflow to d+1 digits when
+    we meant to use d digits).
+*/
+
 /**
- * Returns sequence functions for the given base.
- *
- * @param base Must be even and >= 4. (For a base-2 sequence, binary encode the base-4 sequence.)
+ * Checks that `base` is valid.
  */
-export function lexSequence(base: number) {
-  if (!Number.isSafeInteger(base) || base % 2 !== 0 || base < 4) {
+function checkBase(base: number): void {
+  if (!(Number.isSafeInteger(base) && base % 2 === 0 && base >= 4)) {
     throw new Error(`lex-sequence base must be an even integer >= 4: ${base}`);
   }
+}
 
-  const logBase = Math.log(base);
+/**
+ * Returns the length in `base` digits.
+ */
+function len(seq: number, base: number): number {
+  return seq === 0 ? 1 : Math.floor(Math.log(seq) / Math.log(base)) + 1;
+}
 
-  /*
-    The sequence is as follows, with examples in base 10:
+/**
+ * Returns the first number in the sequence that has the given number of digits.
+ */
+function first(d: number, base: number): number {
+  // You can calculate that the first d-digit number is BASE^d - BASE * (BASE/2)^(d-1).
+  return Math.pow(base, d) - base * Math.pow(base / 2, d - 1);
+}
 
-    1. Starting with 0, enumerate `BASE/2` numbers. (0, 1, ..., 4.)
-    2. Add 1, multiply by `BASE`, then enumerate `(BASE/2)^2` numbers.
-      (50, 51, ..., 74.)
-    3. Add 1, multiply by `BASE`, then enumerate `(BASE/2)^3` numbers.
-      (750, 751, ..., 874.)
-    4. Repeat this pattern indefinitely, enumerating
-      `(BASE/2)^d` length-d numbers for each d >= 1. Imagining a decimal place
-      in front of each number, each d consumes 2^(-d) of the unit interval,
-      so we never "reach 1" (overflow to d+1 digits when
-      we meant to use d digits).
-  */
+/**
+ * Returns the last number in the sequence that has the given number of digits.
+ */
+function last(d: number, base: number): number {
+  // You can calculate that the last d-digit number is BASE^d - (BASE/2)^d - 1.
+  return Math.pow(base, d) - Math.pow(base / 2, d) - 1;
+}
 
-  /**
-   * Returns the length in BASE digits.
-   */
-  function len(seq: number): number {
-    return seq === 0 ? 1 : Math.floor(Math.log(seq) / logBase) + 1;
+/**
+ * Given a number in the sequence, outputs the next number in the sequence.
+ *
+ * To yield the sequence in order, call this function repeatedly starting at 0.
+ */
+export function successor(seq: number, base: number): number {
+  checkBase(base);
+
+  if (seq === last(len(seq, base), base)) {
+    // New length: seq -> (seq + 1) * BASE.
+    return (seq + 1) * base;
+  } else {
+    // seq -> seq + 1.
+    return seq + 1;
   }
+}
 
-  /**
-   * Returns the first number in the sequence that has the given number of digits.
-   */
-  function first(d: number): number {
-    // You can calculate that the first d-digit number is BASE^d - BASE * (BASE/2)^(d-1).
-    return Math.pow(base, d) - base * Math.pow(base / 2, d - 1);
+/**
+ * Returns the n-th number in the sequence.
+ */
+export function sequence(index: number, base: number): number {
+  checkBase(base);
+
+  // Each digit-length d has (BASE/2)^d values. Subtract these
+  // out until we can't anymore (reached the right length).
+  let remaining = index;
+  let d = 1;
+  for (; ; d++) {
+    const valueCount = Math.pow(base / 2, d);
+    if (remaining < valueCount) break;
+    remaining -= valueCount;
   }
+  // The number is d-digits long, and at index `remaining` within
+  // the d-digit subsequence.
+  // So add `remaining` to the first d-digit number.
+  return remaining + first(d, base);
+}
 
-  /**
-   * Returns the last number in the sequence that has the given number of digits.
-   */
-  function last(d: number): number {
-    // You can calculate that the last d-digit number is BASE^d - (BASE/2)^d - 1.
-    return Math.pow(base, d) - Math.pow(base / 2, d) - 1;
+/**
+ * Inverse of {@link sequence}: returns the index of seq in the sequence.
+ *
+ * If seq is not a member of the sequence, returns -1, unlike {@link sequenceInv}
+ * which throws an error. So you can use this function to test if
+ * seq is a member of the sequence.
+ */
+export function sequenceInvSafe(seq: number, base: number): number {
+  checkBase(base);
+
+  if (!Number.isSafeInteger(seq) || seq < 0) return -1;
+
+  const d = len(seq, base);
+  // Check how far we are from the first d-digit number,
+  // i.e., our index in the d-digit sub-sequence.
+  let ans = seq - first(d, base);
+  if (ans < 0 || ans >= Math.pow(base / 2, d)) {
+    // Valid indexes within the d-digit sub-sequence are [0, (BASE/2)^d).
+    // We are outside of that range, therefore seq is invalid.
+    return -1;
   }
-
-  /**
-   * Given a number in the sequence, outputs the next number in the sequence.
-   *
-   * To yield the sequence in order, call this function repeatedly starting at 0.
-   */
-  function successor(seq: number): number {
-    if (seq === last(len(seq))) {
-      // New length: seq -> (seq + 1) * BASE.
-      return (seq + 1) * base;
-    } else {
-      // seq -> seq + 1.
-      return seq + 1;
-    }
+  // Previous digit-lengths d2 have (BASE/2)^d2 values each.
+  for (let d2 = 1; d2 < d; d2++) {
+    ans += Math.pow(base / 2, d2);
   }
+  return ans;
+}
 
-  /**
-   * Returns the n-th number in the sequence.
-   */
-  function sequence(index: number): number {
-    // Each digit-length d has (BASE/2)^d values. Subtract these
-    // out until we can't anymore (reached the right length).
-    let remaining = index;
-    let d = 1;
-    for (; ; d++) {
-      const valueCount = Math.pow(base / 2, d);
-      if (remaining < valueCount) break;
-      remaining -= valueCount;
-    }
-    // The number is d-digits long, and at index `remaining` within
-    // the d-digit subsequence.
-    // So add `remaining` to the first d-digit number.
-    return remaining + first(d);
+/**
+ * Inverse of {@link sequence}: returns the index of seq in the sequence.
+ *
+ * @throws If seq is not a member of the sequence. (To test membership
+ * without a try-catch, call {@link sequenceInvSafe} and check for output -1.)
+ */
+export function sequenceInv(seq: number, base: number): number {
+  const ans = sequenceInvSafe(seq, base);
+  if (ans === -1) {
+    throw new Error(`Not a lex-sequence member: ${seq}`);
   }
-
-  /**
-   * Inverse of sequence: returns the index n of seq in the sequence.
-   *
-   * If seq is not a member of the sequence, returns -1, unlike sequenceInv
-   * which throws an error. So you can use this function to test if
-   * seq is a member of the sequence.
-   */
-  function sequenceInvSafe(seq: number): number {
-    if (!Number.isSafeInteger(seq) || seq < 0) return -1;
-
-    const d = len(seq);
-    // Check how far we are from the first d-digit number,
-    // i.e., our index in the d-digit sub-sequence.
-    let ans = seq - first(d);
-    if (ans < 0 || ans >= Math.pow(base / 2, d)) {
-      // Valid indexes within the d-digit sub-sequence are [0, (BASE/2)^d).
-      // We are outside of that range, therefore seq is invalid.
-      return -1;
-    }
-    // Previous digit-lengths d2 have (BASE/2)^d2 values each.
-    for (let d2 = 1; d2 < d; d2++) {
-      ans += Math.pow(base / 2, d2);
-    }
-    return ans;
-  }
-
-  /**
-   * Inverse of sequence: returns the index of seq in the sequence.
-   *
-   * @throws If seq is not a member of the sequence. (To test membership
-   * without a try-catch, call sequenceInvSafe and check for output -1.)
-   */
-  function sequenceInv(seq: number): number {
-    const ans = sequenceInvSafe(seq);
-    if (ans === -1) {
-      throw new Error(`Not a lex-sequence member: ${seq}`);
-    }
-    return ans;
-  }
-
-  return { sequence, sequenceInv, sequenceInvSafe, successor };
+  return ans;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,16 +84,16 @@ export function sequence(index: number, base: number): number {
 }
 
 /**
- * Inverse of {@link sequence}: returns the index of seq in the sequence.
+ * Inverse of {@link sequence}: returns the index of `seq` in the sequence.
  *
- * If seq is not a member of the sequence, returns -1, unlike {@link sequenceInv}
+ * If `seq` is not a member of the sequence, returns -1, unlike {@link sequenceInv}
  * which throws an error. So you can use this function to test if
- * seq is a member of the sequence.
+ * `seq` is a member of the sequence.
  */
 export function sequenceInvSafe(seq: number, base: number): number {
   checkBase(base);
 
-  if (!Number.isSafeInteger(seq) || seq < 0) return -1;
+  if (!(Number.isSafeInteger(seq) && seq >= 0)) return -1;
 
   const d = len(seq, base);
   // Check how far we are from the first d-digit number,
@@ -112,9 +112,9 @@ export function sequenceInvSafe(seq: number, base: number): number {
 }
 
 /**
- * Inverse of {@link sequence}: returns the index of seq in the sequence.
+ * Inverse of {@link sequence}: returns the index of `seq` in the sequence.
  *
- * @throws If seq is not a member of the sequence. (To test membership
+ * @throws If `seq` is not a member of the sequence. (To test membership
  * without a try-catch, call {@link sequenceInvSafe} and check for output -1.)
  */
 export function sequenceInv(seq: number, base: number): number {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,26 +1,26 @@
 import { assert } from "chai";
 import { describe, test } from "mocha";
-import { lexSequence } from "../src";
+import { sequence, sequenceInv, sequenceInvSafe, successor } from "../src";
 
 describe("lex-sequence", () => {
+  test("invalid base", () => {
+    for (const invalidBase of [0, 1, 2, 3, 25, -1, 0.5, NaN]) {
+      assert.throws(() => sequence(0, invalidBase));
+      assert.throws(() => sequenceInv(0, invalidBase));
+      assert.throws(() => sequenceInvSafe(0, invalidBase));
+      assert.throws(() => successor(0, invalidBase));
+    }
+  });
+
   for (const BASE of [4, 10, 16, 26, 36, 52, 64, 128]) {
-    test("invalid base", () => {
-      for (const invalidBase of [0, 1, 2, 3, 25, -1, 0.5, NaN]) {
-        assert.throws(() => lexSequence(invalidBase));
-      }
-    });
-
     describe(`base ${BASE}`, () => {
-      const { sequence, sequenceInv, sequenceInvSafe, successor } =
-        lexSequence(BASE);
-
       // The first 10k numbers in the sequence, generated with successor().
       const first10k: number[] = [];
 
       before(() => {
         first10k.push(0);
         for (let i = 1; i < 10000; i++) {
-          first10k.push(successor(first10k.at(-1)!));
+          first10k.push(successor(first10k.at(-1)!, BASE));
         }
       });
 
@@ -45,25 +45,25 @@ describe("lex-sequence", () => {
 
       test("sequence", () => {
         for (let i = 0; i < first10k.length; i++) {
-          assert.strictEqual(sequence(i), first10k[i]);
+          assert.strictEqual(sequence(i, BASE), first10k[i]);
         }
       });
 
       test("sequenceInv", () => {
         for (let i = 0; i < first10k.length; i++) {
-          assert.strictEqual(sequenceInv(first10k[i]), i);
+          assert.strictEqual(sequenceInv(first10k[i], BASE), i);
         }
         for (const invalidSeq of [-1, 0.5, NaN, BASE / 2, BASE / 2 + 1]) {
-          assert.throws(() => sequenceInv(invalidSeq));
+          assert.throws(() => sequenceInv(invalidSeq, BASE));
         }
       });
 
       test("sequenceInvSafe", () => {
         for (let i = 0; i < first10k.length; i++) {
-          assert.strictEqual(sequenceInvSafe(first10k[i]), i);
+          assert.strictEqual(sequenceInvSafe(first10k[i], BASE), i);
         }
         for (const invalidSeq of [-1, 0.5, NaN, BASE / 2, BASE / 2 + 1]) {
-          assert.strictEqual(sequenceInvSafe(invalidSeq), -1);
+          assert.strictEqual(sequenceInvSafe(invalidSeq, BASE), -1);
         }
       });
     });


### PR DESCRIPTION
Instead of a top-level function that inputs a base and outputs the real functions.

For tree-shaking.